### PR TITLE
reduce revalidation period

### DIFF
--- a/frontend/app/[locale]/page.tsx
+++ b/frontend/app/[locale]/page.tsx
@@ -20,16 +20,16 @@ const getRestaurantData = async (locale: string) => {
     restaurantShorthands.map((shorthand) =>
       axios
         .get(
-          `${process.env.BACKEND_API_URL}/restaurant?name=${shorthand}&lang=${locale}`,
+          `${process.env.BACKEND_API_URL}/restaurant?name=${shorthand}&lang=${locale}`
         )
-        .then((response) => response.data),
-    ),
+        .then((response) => response.data)
+    )
   );
   return restaurantData;
 };
 
 // 6 hours
-export const revalidate = 6 * 6 * 60;
+export const revalidate = 6 * 60 * 60;
 
 type Props = { params: { locale?: string } };
 


### PR DESCRIPTION
## Description

<!--- Describe the changes -->

- Reduce revalidation from 12 hours to 6 hours.
- This is my understanding of how this works or at least should work: 

The application rebuilds every 6 hours, and in the process always fetches data directly from restaurant websites because caching in `main.py` is disabled.

However, after the application is rebuilt, it uses the same data (and does not make calls to the websites). The data is cached **server-side**? 

If the data is cached client side then I think it should be changed, because the data is same for all and should be collected only once in 6 hour periods.
