### PR TITLE
fix: increase httpx client timeout

### DIFF
--- a/backend/get_lunch_info.py
+++ b/backend/get_lunch_info.py
@@ -56,13 +56,13 @@ class RestaurantScraper:
             raise ValueError(f"Language not supported: {lang}")
 
     async def fetch_html_content(self, lang="fi"):
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=10) as client:
             response = await client.get(self.lang_urls[lang], headers=self.headers)
             response.raise_for_status()
             return response.content
 
     async def fetch_pdf_content(self, url):
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=10) as client:
             response = await client.get(url, headers=self.headers)
             response.raise_for_status()
             return response.content


### PR DESCRIPTION
## Description

Set httpx network timeout to 10s from default of 5s.
https://www.python-httpx.org/advanced/timeouts/

I think this is why some of the restaurants are erroring out, saw this in the logs:
```
receive_response_headers.failed exception=ReadTimeout(TimeoutError())
```

Might have to revert to the old way of doing things if this doesn't work.

## Screenshot

![image](https://github.com/user-attachments/assets/08a44ad7-4e17-401f-8073-087c808d54de)
