### PR TITLE
ci: use flyctl-actions to set up fly cli

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,12 +14,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Install Flyctl
-        run: |
-          curl -L https://fly.io/install.sh | sh
-          export PATH="$HOME/.fly/bin:$PATH"
-
       - name: Deploy Backend to Fly.io
+      - uses: superfly/flyctl-actions/setup-flyctl@master
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
           FLY_APP_NAME: ${{ secrets.FLY_BACKEND_APP_NAME }}
@@ -34,12 +30,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Install Flyctl
-        run: |
-          curl -L https://fly.io/install.sh | sh
-          export PATH="$HOME/.fly/bin:$PATH"
-
       - name: Deploy Frontend to Fly.io
+      - uses: superfly/flyctl-actions/setup-flyctl@master
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
           FLY_APP_NAME: ${{ secrets.FLY_FRONTEND_APP_NAME }}


### PR DESCRIPTION
## Description

Let's hope this fixes the deploy workflow. Uses superfly/flyctl-actions to set up fly CLI: https://fly.io/docs/launch/continuous-deployment-with-github-actions/