### PR TITLE
Add manual deployment trigger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   # Job to deploy the backend


### PR DESCRIPTION
## Description

<!-- Provide a detailed description of the changes introduced by this PR -->

- Add a manual trigger to deploy frontend and backend.
- It seems that your second merged PR (student icon) might not have been deployed properly, despite the successful action. For similar cases it can be a good option to have a manual trigger.

Slightly related on the topic, I enabled auto deleting branches when merging.
<img width="1038" alt="image" src="https://github.com/user-attachments/assets/3f485c60-0daa-45ca-b198-6f571bab0708">
