### PR TITLE
chore: add revalidate API route and revalidate CI job

### DIFF
--- a/.github/workflows/revalidate.yml
+++ b/.github/workflows/revalidate.yml
@@ -1,0 +1,16 @@
+name: Revalidate Pages
+
+on:
+  schedule:
+    # Revalidate once per day at midnight UTC
+    - cron: '0 0 * * *'
+  # Allow manual trigger
+  workflow_dispatch:
+
+jobs:
+  revalidate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger revalidation
+        run: |
+          curl -X GET 'https://lunssi.fly.dev/api/revalidate?token=${{ secrets.REVALIDATION_TOKEN }}'

--- a/frontend/app/api/revalidate/route.ts
+++ b/frontend/app/api/revalidate/route.ts
@@ -1,0 +1,40 @@
+import i18nConfig from "@/i18nConfig";
+import { regions } from "@/utils/constants";
+import { revalidatePath } from "next/cache";
+import { NextResponse } from "next/server";
+
+// Add a secret token to prevent unauthorized revalidation
+const REVALIDATION_TOKEN = process.env.REVALIDATION_TOKEN;
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const token = searchParams.get("token");
+
+  // Validate the token
+  if (token !== REVALIDATION_TOKEN) {
+    return NextResponse.json({ message: "Invalid token" }, { status: 401 });
+  }
+
+  try {
+    // Revalidate the home page and all region pages for both languages
+    for (const locale of i18nConfig.locales) {
+      // Revalidate base paths
+      revalidatePath(`/${locale}`);
+
+      // Revalidate all region paths
+      for (const region of regions) {
+        revalidatePath(`/${locale}/${region.id}`);
+      }
+    }
+
+    return NextResponse.json({
+      revalidated: true,
+      timestamp: Date.now(),
+    });
+  } catch (err) {
+    return NextResponse.json(
+      { message: "Error revalidating", error: err },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Description

Adds a revalidation API route, and a CI cron job to call it once a day. Revalidation means that Next.js purges the cache, so when a user loads the page, it will be regenerated. This way the user should never see old menus.

Right now, our site works like this:

1. During next build, all pages are generated
2. All requests made to these pages are cached and instantaneous
3. After 6 hours has passed, the next request will still show the cached (stale) page
4. The cache is invalidated and a new version of the page begins generating in the background
5. Once generated successfully, Next.js will display and cache the updated page

So this is to avoid 3. from happening.

We need to add a `REVALIDATION_TOKEN` to the repo secrets and to fly io secrets for this to work.

