### PR TITLE
fix: don't include default region in path

### DIFF
--- a/frontend/app/[locale]/[region]/page.tsx
+++ b/frontend/app/[locale]/[region]/page.tsx
@@ -4,7 +4,7 @@ import RegionChanger from "@/components/RegionChanger";
 import RestaurantCard from "@/components/RestaurantCard";
 import TranslationsProvider from "@/components/TranslationProvider";
 import { getRestaurantData } from "@/lib/restaurants";
-import { regions } from "@/utils/constants";
+import { defaultRegion, regions } from "@/utils/constants";
 import { getLocalizedLink } from "@/utils/helpers";
 import type { Metadata } from "next";
 import React from "react";
@@ -38,9 +38,11 @@ export const generateMetadata = async (props: Props): Promise<Metadata> => {
 
 export const generateStaticParams = async (props: Props) => {
   const params = await props.params;
-  return regions.map(({ id }) => {
-    return { locale: params.locale, region: id };
-  });
+  return regions
+    .filter(({ id }) => id !== defaultRegion)
+    .map(({ id }) => {
+      return { locale: params.locale, region: id };
+    });
 };
 
 const Region = async (props: Props) => {

--- a/frontend/components/RegionChanger.tsx
+++ b/frontend/components/RegionChanger.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import ChevronDownIcon from "@/assets/icons/chevron-down.svg";
-import { regions } from "@/utils/constants";
+import { defaultRegion, regions } from "@/utils/constants";
 import { usePathname, useRouter } from "next/navigation";
 import type { ChangeEvent } from "react";
 import React from "react";
@@ -21,7 +21,9 @@ const RegionChanger = ({ currentRegion }: Props) => {
     const newPath = pathname.includes(currentRegion)
       ? pathname.replace(currentRegion, newRegion)
       : `/${newRegion}`;
-    router.push(newPath);
+
+    // don't include default region in path
+    router.push(newPath.replace(`/${defaultRegion}`, "/"));
   };
 
   return (


### PR DESCRIPTION
## Description

This is a small fix so that we dont build the `/defaultRegion` path, in this case, `/kamppi`. Instead we use the index page`/` to show the menus of the default region.
