### PR TITLE
Chore: define max machines

### DIFF
--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -17,6 +17,7 @@ primary_region = 'arn'
   force_https = true
   auto_stop_machines = 'stop'
   auto_start_machines = true
+  max_machines_running = 1
   min_machines_running = 1
   processes = ['app']
 

--- a/frontend/fly.toml
+++ b/frontend/fly.toml
@@ -13,6 +13,7 @@ primary_region = 'arn'
   force_https = true
   auto_stop_machines = 'stop'
   auto_start_machines = true
+  max_machines_running = 1
   min_machines_running = 1
   processes = ['app']
 


### PR DESCRIPTION
## Description

<!-- Provide a detailed description of the changes introduced by this PR -->

<!-- Please link the issue this PR addresses. Use "Closes", "Fixes", or
"Resolves" keywords to automatically close the issue when the PR is merged. -->
Closes #[issue number]

- Define `max_machines` for the frontend and backend. 
- Currently, the automatically decided machines are 4 for backend and 2 for frontend. This led to some costs (5€+) last month. This is not bad, but I'd like to avoid them if possible.
- Let's start with 1+1 machines and scale up if needed. 
- I have been a bit hesitant to open `DEV` hosting, as I don't want to pay until we need it, but at least it should not require this many machines running. This can be a good test also regarding it to see if 1 + 1 machines is enough for `DEV` purposes.