### PR TITLE
Fix: remove max machines running

### DIFF
--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -17,7 +17,6 @@ primary_region = 'arn'
   force_https = true
   auto_stop_machines = 'stop'
   auto_start_machines = true
-  max_machines_running = 1
   min_machines_running = 1
   processes = ['app']
 

--- a/frontend/fly.toml
+++ b/frontend/fly.toml
@@ -13,7 +13,6 @@ primary_region = 'arn'
   force_https = true
   auto_stop_machines = 'stop'
   auto_start_machines = true
-  max_machines_running = 1
   min_machines_running = 1
   processes = ['app']
 


### PR DESCRIPTION
## Description

<!-- Provide a detailed description of the changes introduced by this PR -->

- Apparently there was a mistake in the `fly.toml` configuration and `max_machines_running` did not do anything. I removed unused machines in the fly portal.


![image](https://github.com/user-attachments/assets/8ed90c7d-8325-4ebe-8852-67584d88d340)


 
