### PR TITLE
Fix: replace GA tracking id with GTM container id

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,4 +1,4 @@
 # LOCAL: http://localhost:8080
 # PRD: https://lunssi-backend.fly.dev
 BACKEND_API_URL=http://localhost:8080
-NEXT_PUBLIC_GA_TRACKING_ID=G-XXXXXXXXXX # Replace
+NEXT_PUBLIC_GTM_CONTAINER_ID=GTM-XXXXXXXX # Replace with the GTM container ID

--- a/frontend/app/[locale]/layout.tsx
+++ b/frontend/app/[locale]/layout.tsx
@@ -36,7 +36,7 @@ export default async function RootLayout(props: {
 
   const { children } = props;
 
-  const gtmId = process.env.NEXT_PUBLIC_GA_TRACKING_ID ?? "";
+  const gtmId = process.env.NEXT_PUBLIC_GTM_CONTAINER_ID ?? "";
 
   return (
     <html lang={locale} className={roboto.className}>


### PR DESCRIPTION
## Description

<!-- Provide a detailed description of the changes introduced by this PR -->
- Change Google Analytics tracking id to Google Tag Manager container id. These are different, and the Next.js implementation need the latter. GTM is also better for creating more advanced analytics.

![image](https://github.com/user-attachments/assets/4df77164-14a6-4abd-8354-5783500dffa1)

